### PR TITLE
Include customer phone in sell report filter

### DIFF
--- a/application/modules/reports/controllers/Sell_report.php
+++ b/application/modules/reports/controllers/Sell_report.php
@@ -33,7 +33,7 @@ class Sell_report extends MX_Controller
         $config['link_func'] = 'searchFilter';
         $this->ajax_pagination->initialize($config);
 
-        $data['customers'] = $this->sell_report_model->getvalue_row('customers', 'id_customer,full_name', array('status_id' => 1));
+        $data['customers'] = $this->sell_report_model->getvalue_row('customers', 'id_customer,full_name,phone', array('status_id' => 1));
         $data['customer_types'] = $this->sell_report_model->getvalue_row('customer_types', 'id_customer_type,name', array('status_id' => 1));
         $data['stations'] = $this->sell_report_model->getvalue_row('stations', 'id_station,name', array('status_id' => 1));
         $type = $this->session->userdata['login_info']['user_type_i92'];

--- a/application/modules/reports/views/sell_report/index.php
+++ b/application/modules/reports/views/sell_report/index.php
@@ -100,7 +100,8 @@
                    <?php
                    foreach ($customers as $customer) {
                      if (empty($customer->_id_customer)) {
-                       echo '<option value="' . $customer->id_customer . '">' . $customer->full_name . '</option>';
+                       $text = sprintf('%s(%s) - %s', $customer->full_name, $customer->id_customer, $customer->phone);
+                       echo sprintf('<option value="%s" data-tokens="%s %s">%s</option>', $customer->id_customer, $customer->id_customer, $customer->phone, $text);
                      }
                    }
                    ?>


### PR DESCRIPTION
## Summary
- Expand sell report's customer fetch to include phone numbers
- Display customer name with ID and phone in report filter options for improved searching

## Testing
- `php -l application/modules/reports/controllers/Sell_report.php`
- `php -l application/modules/reports/views/sell_report/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6897067240488327bc8c7116ee0f84da