### PR TITLE
Include customer code in Sell Report dropdown

### DIFF
--- a/application/modules/reports/controllers/Sell_report.php
+++ b/application/modules/reports/controllers/Sell_report.php
@@ -33,7 +33,7 @@ class Sell_report extends MX_Controller
         $config['link_func'] = 'searchFilter';
         $this->ajax_pagination->initialize($config);
 
-        $data['customers'] = $this->sell_report_model->getvalue_row('customers', 'id_customer,full_name,phone', array('status_id' => 1));
+        $data['customers'] = $this->sell_report_model->getvalue_row('customers', 'id_customer,customer_code,full_name,phone', array('status_id' => 1));
         $data['customer_types'] = $this->sell_report_model->getvalue_row('customer_types', 'id_customer_type,name', array('status_id' => 1));
         $data['stations'] = $this->sell_report_model->getvalue_row('stations', 'id_station,name', array('status_id' => 1));
         $type = $this->session->userdata['login_info']['user_type_i92'];

--- a/application/modules/reports/views/sell_report/index.php
+++ b/application/modules/reports/views/sell_report/index.php
@@ -98,12 +98,12 @@
                   <select class="select2" data-live-search="true" id="customer_id" name="customer_id">
                    <option value="0" selected><?= lang("select_one"); ?></option>
                    <?php
-                   foreach ($customers as $customer) {
-                     if (empty($customer->_id_customer)) {
-                       $text = sprintf('%s(%s) - %s', $customer->full_name, $customer->id_customer, $customer->phone);
-                       echo sprintf('<option value="%s" data-tokens="%s %s">%s</option>', $customer->id_customer, $customer->id_customer, $customer->phone, $text);
-                     }
-                   }
+                    foreach ($customers as $customer) {
+                      if (empty($customer->_id_customer)) {
+                        $text = sprintf('%s(%s) - %s', $customer->full_name, $customer->customer_code, $customer->phone);
+                        echo sprintf('<option value="%s" data-tokens="%s %s">%s</option>', $customer->id_customer, $customer->customer_code, $customer->phone, $text);
+                      }
+                    }
                    ?>
                  </select>
                </div>


### PR DESCRIPTION
## Summary
- include customer code and phone when fetching Sell Report customers
- show customer code and phone in Sell Report customer dropdown

## Testing
- `php -l application/modules/reports/controllers/Sell_report.php`
- `php -l application/modules/reports/views/sell_report/index.php`
- `curl -s -D - 127.0.0.1:8000/index.php/reports/sell_report/index` *(fails: HTTP 500)*

------
https://chatgpt.com/codex/tasks/task_e_68970b65a2648327979e59f92a6bc764